### PR TITLE
Player card edits

### DIFF
--- a/CSV/Card/4.txt
+++ b/CSV/Card/4.txt
@@ -1,7 +1,7 @@
 default
 @初期化
 &カード名,Book Maker
-&効果テキスト,When this card is normal summoned; decrease it's life points by 500 and add one random magic card to your hand.
+&効果テキスト,When this card is normal summoned; pay 500 life points to add 1 random Magic card from your deck to your hand.
 &ハード効果テキスト,
 &イージー効果テキスト,
 &フレーバーテキスト,

--- a/CSV/Card/40009.txt
+++ b/CSV/Card/40009.txt
@@ -1,7 +1,7 @@
 default
 @初期化
 &カード名,Life Up
-&効果テキスト,Increases player Max HP by 500 points. Furthermore; if you end your turn with no monsters on the field; draw 1 card.
+&効果テキスト,Increases player Max HP by 500 points. At the end of this turn; if there are no monsters on your field; draw 1 card.
 &ハード効果テキスト,
 &イージー効果テキスト,
 &フレーバーテキスト,

--- a/CSV/Card/50004.txt
+++ b/CSV/Card/50004.txt
@@ -1,7 +1,7 @@
 default
 @初期化
 &カード名,Steel Trap
-&効果テキスト,Activates on an opponent's normal summon. Deals 1000 points to that monster; and cannot attack until the opponent's turn ends.
+&効果テキスト,Activates on an opponent's normal summon. The summoned monster takes 1000 points of damage and cannot attack until end of turn.
 &ハード効果テキスト,
 &イージー効果テキスト,
 &フレーバーテキスト,


### PR DESCRIPTION
4
The cost is paid from the player life, not from monster HP. I believe life points refer exclusively to the player.

40009
Missing "THIS turn" and "YOUR field". Changed formatting for the clearer.

50004
Improper grammar.
The formatting for traps could also be changed to "Activatable when *condition*."